### PR TITLE
52 issues with running make on campus workstation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,12 +15,18 @@ REDIS_PORT=6379
 # Host port mappings (change these if you have port collisions on your machine)
 DB_EXPOSED_PORT=5432
 REDIS_EXPOSED_PORT=6379
+HTTP_EXPOSED_PORT=8080
+HTTPS_EXPOSED_PORT=8443
+
+# Dev-specific host port mappings (to avoid conflict with production stack)
+DEV_DB_EXPOSED_PORT=5433
+DEV_REDIS_EXPOSED_PORT=6380
 
 # --- Django Configuration ---
 DEBUG=True
 SECRET_KEY=example_django_secret_key
-ALLOWED_HOSTS=localhost,127.0.0.1
-CSRF_TRUSTED_ORIGINS=https://localhost:8443,https://127.0.0.1:8443
+ALLOWED_HOSTS=localhost,127.0.0.1,localhost:${HTTPS_EXPOSED_PORT},127.0.0.1:${HTTPS_EXPOSED_PORT}
+CSRF_TRUSTED_ORIGINS=https://localhost:${HTTPS_EXPOSED_PORT},https://127.0.0.1:${HTTPS_EXPOSED_PORT}
 REDIS_HOST=redis
 
 # --- AI Configuration ---

--- a/.env.example
+++ b/.env.example
@@ -13,14 +13,15 @@ DB_PORT=5432
 REDIS_PORT=6379
 
 # Host port mappings (change these if you have port collisions on your machine)
+# standard: POSTGRES 5432, REDIS 6379, HTTP 80, HTTPS 443
 DB_EXPOSED_PORT=5432
-REDIS_EXPOSED_PORT=6379
+REDIS_EXPOSED_PORT=6380
 HTTP_EXPOSED_PORT=8080
 HTTPS_EXPOSED_PORT=8443
 
 # Dev-specific host port mappings (to avoid conflict with production stack)
 DEV_DB_EXPOSED_PORT=5433
-DEV_REDIS_EXPOSED_PORT=6380
+DEV_REDIS_EXPOSED_PORT=6381
 
 # --- Django Configuration ---
 DEBUG=True

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ dev-venv:
 		python3 -m venv .venv; \
 	fi
 	@echo "Installing/Updating requirements..."
-	@. .venv/bin/activate && pip install --upgrade pip && pip install -r server/requirements.txt
+	@source .venv/bin/activate
+	@pip install --upgrade pip && pip install -r server/requirements.txt
 
 # Start only DB and Redis for local dev
 dev-up: dev-venv

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,28 @@ DOCKER_COMPOSE_FILE = ./devops/docker-compose.yml
 PROD_PROJECT = prod-transcendence
 DEV_PROJECT = dev-transcendence
 
+# Load environment variables from .env if it exists
+-include .env
+
+# Default port values (can be overridden in .env)
+DB_EXPOSED_PORT ?= 5432
+REDIS_EXPOSED_PORT ?= 6379
+HTTP_EXPOSED_PORT ?= 8080
+HTTPS_EXPOSED_PORT ?= 8443
+
+DEV_DB_EXPOSED_PORT ?= 5433
+DEV_REDIS_EXPOSED_PORT ?= 6380
+
 # Default target
 all: up
 
 # Build and start the stack in detached mode
 up:
 	@echo "Starting the stack (Production)..."
+	DB_EXPOSED_PORT=$(DB_EXPOSED_PORT) \
+	REDIS_EXPOSED_PORT=$(REDIS_EXPOSED_PORT) \
+	HTTP_EXPOSED_PORT=$(HTTP_EXPOSED_PORT) \
+	HTTPS_EXPOSED_PORT=$(HTTPS_EXPOSED_PORT) \
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(PROD_PROJECT) up -d --build
 
 # Stop the stack
@@ -57,58 +73,58 @@ dev-venv:
 # Start only DB and Redis for local dev
 dev-up: dev-venv
 	@echo "Starting DB and Redis (Dev)..."
-	DB_EXPOSED_PORT=5433 REDIS_EXPOSED_PORT=6380 $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(DEV_PROJECT) up -d db redis
+	DB_EXPOSED_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_EXPOSED_PORT=$(DEV_REDIS_EXPOSED_PORT) $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(DEV_PROJECT) up -d db redis
 
 dev-shell: dev-up
 	@echo "Opening Django shell locally..."
-	cd server && DB_HOST=127.0.0.1 DB_PORT=5433 REDIS_HOST=127.0.0.1 REDIS_PORT=6380 python3 manage.py shell
+	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) python3 manage.py shell
 
 # Run migrations locally
 dev-migrate: dev-up
 	@echo "Running migrations locally (Dev)..."
-	cd server && DB_HOST=127.0.0.1 DB_PORT=5433 REDIS_HOST=127.0.0.1 REDIS_PORT=6380 python3 manage.py migrate
+	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) python3 manage.py migrate
 
 # Stop only DB and Redis
 dev-down:
 	@echo "Stopping DB and Redis (Dev)..."
-	DB_EXPOSED_PORT=5433 REDIS_EXPOSED_PORT=6380 $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(DEV_PROJECT) stop db redis
+	DB_EXPOSED_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_EXPOSED_PORT=$(DEV_REDIS_EXPOSED_PORT) $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(DEV_PROJECT) stop db redis
 
 # Stop and wipe dev volumes (Isolated from production)
 dev-clean: check_clean
 	@echo "Cleaning dev stack..."
-	DB_EXPOSED_PORT=5433 REDIS_EXPOSED_PORT=6380 $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(DEV_PROJECT) down -v
+	DB_EXPOSED_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_EXPOSED_PORT=$(DEV_REDIS_EXPOSED_PORT) $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(DEV_PROJECT) down -v
 
 # Show logs for dev stack
 dev-logs:
-	DB_EXPOSED_PORT=5433 REDIS_EXPOSED_PORT=6380 $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(DEV_PROJECT) logs -f
+	DB_EXPOSED_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_EXPOSED_PORT=$(DEV_REDIS_EXPOSED_PORT) $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(DEV_PROJECT) logs -f
 
 # Run Django locally
 dev-runserver: dev-up
 	@echo "Running Django locally..."
-	cd server && DB_HOST=127.0.0.1 DB_PORT=5433 REDIS_HOST=127.0.0.1 REDIS_PORT=6380 python3 manage.py runserver
+	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) python3 manage.py runserver
 
 # Run tests locally
 dev-test: dev-up
 	@echo "Running tests locally..."
-	cd server && DB_HOST=127.0.0.1 DB_PORT=5433 REDIS_HOST=127.0.0.1 REDIS_PORT=6380 python3 manage.py test
+	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) python3 manage.py test
 
 # Create superuser locally
 dev-createsuperuser: dev-up
 	@echo "Creating superuser locally..."
-	cd server && DB_HOST=127.0.0.1 DB_PORT=5433 REDIS_HOST=127.0.0.1 REDIS_PORT=6380 python3 manage.py createsuperuser
+	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) python3 manage.py createsuperuser
 
 # Check container status
 ps:
 	@echo "--- Production Stack ---"
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(PROD_PROJECT) ps
 	@echo "\n--- Dev Stack ---"
-	DB_EXPOSED_PORT=5433 REDIS_EXPOSED_PORT=6380 $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(DEV_PROJECT) ps
+	DB_EXPOSED_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_EXPOSED_PORT=$(DEV_REDIS_EXPOSED_PORT) $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) -p $(DEV_PROJECT) ps
 
 check_fclean:
 	@echo -n "Are you sure? This will remove all the docker objects on the system (including other directories) [y/N] " && read ans && [ $${ans:-N} = y ]
 
 # WARNING: Will prune all the docker objects on the system
-fclean: check_fclean clean
+fclean: check_fclean clean dev-clean
 	@echo "Deep cleaning docker system..."
 	docker system prune -a --volumes -f
 

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ dev-venv:
 	@echo "Installing/Updating requirements..."
 	@. .venv/bin/activate && pip install --upgrade pip && pip install -r server/requirements.txt
 
+VENV_PYTHON = ../.venv/bin/python3
+
 # Start only DB and Redis for local dev
 dev-up: dev-venv
 	@echo "Starting DB and Redis (Dev)..."
@@ -77,12 +79,12 @@ dev-up: dev-venv
 
 dev-shell: dev-up
 	@echo "Opening Django shell locally..."
-	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) python3 manage.py shell
+	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) $(VENV_PYTHON) manage.py shell
 
 # Run migrations locally
 dev-migrate: dev-up
 	@echo "Running migrations locally (Dev)..."
-	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) python3 manage.py migrate
+	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) $(VENV_PYTHON) manage.py migrate
 
 # Stop only DB and Redis
 dev-down:
@@ -101,17 +103,17 @@ dev-logs:
 # Run Django locally
 dev-runserver: dev-up
 	@echo "Running Django locally..."
-	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) python3 manage.py runserver
+	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) $(VENV_PYTHON) manage.py runserver
 
 # Run tests locally
 dev-test: dev-up
 	@echo "Running tests locally..."
-	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) python3 manage.py test
+	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) $(VENV_PYTHON) manage.py test
 
 # Create superuser locally
 dev-createsuperuser: dev-up
 	@echo "Creating superuser locally..."
-	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) python3 manage.py createsuperuser
+	cd server && DB_HOST=127.0.0.1 DB_PORT=$(DEV_DB_EXPOSED_PORT) REDIS_HOST=127.0.0.1 REDIS_PORT=$(DEV_REDIS_EXPOSED_PORT) $(VENV_PYTHON) manage.py createsuperuser
 
 # Check container status
 ps:

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,7 @@ dev-venv:
 		python3 -m venv .venv; \
 	fi
 	@echo "Installing/Updating requirements..."
-	@source .venv/bin/activate
-	@pip install --upgrade pip && pip install -r server/requirements.txt
+	@. .venv/bin/activate && pip install --upgrade pip && pip install -r server/requirements.txt
 
 # Start only DB and Redis for local dev
 dev-up: dev-venv

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       context: ..
       dockerfile: devops/nginx/Dockerfile
     ports:
-      - "8080:80"
-      - "8443:443"
+      - "${HTTP_EXPOSED_PORT:-8080}:80"
+      - "${HTTPS_EXPOSED_PORT:-8443}:443"
     volumes:
       - static_data:/app/static:ro
       - media_data:/app/media:ro

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -51,6 +51,8 @@ services:
     build:
       context: ..
       dockerfile: devops/nginx/Dockerfile
+    env_file:
+      - ../.env
     ports:
       - "${HTTP_EXPOSED_PORT:-8080}:80"
       - "${HTTPS_EXPOSED_PORT:-8443}:443"

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       - "${DB_EXPOSED_PORT:-5432}:5432"
     networks:
       - backend
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     restart: always
 
   redis:
@@ -21,6 +26,11 @@ services:
       - "${REDIS_EXPOSED_PORT:-6379}:6379"
     networks:
       - backend
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     restart: always
 
   api:
@@ -33,8 +43,10 @@ services:
     env_file:
       - ../.env
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - backend
     restart: always

--- a/devops/nginx/Dockerfile
+++ b/devops/nginx/Dockerfile
@@ -10,8 +10,8 @@ RUN apk add --no-cache openssl
 # Remove default configuration
 RUN rm /etc/nginx/conf.d/default.conf
 
-# Copy custom configuration
-COPY devops/nginx/nginx.conf /etc/nginx/conf.d/
+# Copy custom configuration template
+COPY devops/nginx/nginx.conf.template /etc/nginx/templates/nginx.conf.template
 
 # Generate self-signed SSL certificate (for development/defense)
 RUN mkdir -p /etc/nginx/ssl && \
@@ -22,4 +22,6 @@ RUN mkdir -p /etc/nginx/ssl && \
 # Expose ports
 EXPOSE 80 443
 
+# envsubst is built-in in nginx official docker image entrypoint for .template files in /etc/nginx/templates/
+# See: https://hub.docker.com/_/nginx "Using environment variables in nginx configuration"
 CMD ["nginx", "-g", "daemon off;"]

--- a/devops/nginx/nginx.conf.template
+++ b/devops/nginx/nginx.conf.template
@@ -25,7 +25,7 @@ server {
     # Frontend (React container)
     location / {
         proxy_pass http://web:80; 
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -36,7 +36,7 @@ server {
     # Backend API (generic)
     location /api/ {
         proxy_pass http://django;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -47,7 +47,7 @@ server {
     # Backend Account
     location /account/ {
         proxy_pass http://django;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -57,7 +57,7 @@ server {
     # Backend Game
     location /game/ {
         proxy_pass http://django;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -67,7 +67,7 @@ server {
     # Django Admin
     location /admin/ {
         proxy_pass http://django;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -80,7 +80,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/devops/nginx/nginx.conf.template
+++ b/devops/nginx/nginx.conf.template
@@ -12,7 +12,7 @@ server {
     server_name localhost;
 
     # FORCE HTTPS
-    return 301 https://$host:8443$request_uri;
+    return 301 https://$host:${HTTPS_EXPOSED_PORT}$request_uri;
 }
 
 server {
@@ -26,20 +26,22 @@ server {
     location / {
         proxy_pass http://web:80; 
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Port 8443;
+        proxy_set_header X-Forwarded-Port ${HTTPS_EXPOSED_PORT};
     }
 
     # Backend API (generic)
     location /api/ {
         proxy_pass http://django;
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Port 8443;
+        proxy_set_header X-Forwarded-Port ${HTTPS_EXPOSED_PORT};
     }
 
     # Backend Account
@@ -49,7 +51,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Port 8443;
+        proxy_set_header X-Forwarded-Port ${HTTPS_EXPOSED_PORT};
     }
 
     # Backend Game
@@ -59,7 +61,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Port 8443;
+        proxy_set_header X-Forwarded-Port ${HTTPS_EXPOSED_PORT};
     }
 
     # Django Admin
@@ -69,7 +71,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Port 8443;
+        proxy_set_header X-Forwarded-Port ${HTTPS_EXPOSED_PORT};
     }
 
     # WebSockets
@@ -82,7 +84,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Port 8443;
+        proxy_set_header X-Forwarded-Port ${HTTPS_EXPOSED_PORT};
     }
 
     # Static files (Django)

--- a/devops/nginx/nginx.conf.template
+++ b/devops/nginx/nginx.conf.template
@@ -22,6 +22,9 @@ server {
     ssl_certificate /etc/nginx/ssl/nginx.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx.key;
 
+    # Redirect HTTP to HTTPS on the same port
+    error_page 497 https://$http_host$request_uri;
+
     # Frontend (React container)
     location / {
         proxy_pass http://web:80; 

--- a/devops/nginx/nginx.conf.template
+++ b/devops/nginx/nginx.conf.template
@@ -25,6 +25,8 @@ server {
     # Redirect HTTP to HTTPS on the same port
     error_page 497 https://$http_host$request_uri;
 
+    absolute_redirect off;
+
     # Frontend (React container)
     location / {
         proxy_pass http://web:80; 

--- a/docs/DEV_DOC.md
+++ b/docs/DEV_DOC.md
@@ -8,12 +8,25 @@ For making our lives easier
 
 You need to have python 3.11+ installed.
 
+> [!IMPORTANT]
+> First: create .env based on .env.example
+
 To run the server for the first time (sets up isolated dev database):
 
 ```bash
 make dev-up       # Start DB and Redis
 make dev-migrate  # Run migrations
 make dev-runserver # Start Django
+```
+
+To run production setup:
+
+> [!IMPORTANT]
+> If the default setup does not work it might be because default port is blocked
+> on campus workstation, read the error and change the port in .env in neccesary
+
+```bash
+make up
 ```
 
 ### Codebase

--- a/server/core/settings.py
+++ b/server/core/settings.py
@@ -43,7 +43,8 @@ if not SECRET_KEY:
 
 
 # CSRF settings for production/Docker environment
-_default_origins = "https://localhost:8443,https://127.0.0.1:8443"
+_https_port = os.getenv("HTTPS_EXPOSED_PORT", "8443")
+_default_origins = f"https://localhost:{_https_port},https://127.0.0.1:{_https_port}"
 if DEBUG:
     _default_origins += ",http://localhost:8000,http://127.0.0.1:8000"
 


### PR DESCRIPTION
## Description
- Fixes regarding make issues on campus as well as some quality of life changes

## Linked Issue
Closes #52 

## Changes
### Docs
- Added a disclaimer about port configuration in DEV_DOC.md

### Code
- Improved Makefile modularity by using variable ports overwritten by .env
- dev enviroment setup now calls .venv/bin/python3 directly (fixes error when virtual enviroment is not activated by the user)
- added healthcheck to db and redis as api container depends on them
- fixed redirection when enering django admin as it was annoying 

### Disclaimer
- The default setup still might not work on campus as the default redis port (6379) is already busy on the worksations but I wanted to stick to default ports in default configuration, the port can be easily changed in .env (for example you can make redis port 6380 and dev_redis_exposed_port 6381)