### PR TITLE
38-production-cookie-hsts-hardening

### DIFF
--- a/server/core/settings.py
+++ b/server/core/settings.py
@@ -59,6 +59,19 @@ if DEBUG:
     ALLOWED_HOSTS = ["*"]
 else:
     ALLOWED_HOSTS = get_list_settings("ALLOWED_HOSTS")
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SAMESITE = "Lax"
+    CSRF_COOKIE_SAMESITE = "Lax"
+    SECURE_SSL_REDIRECT = True
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    X_FRAME_OPTIONS = "DENY"
+    SESSION_COOKIE_AGE = 1209600
+    SESSION_SAVE_EVERY_REQUEST = True
 
 
 # Application definition
@@ -213,8 +226,6 @@ if not REDIS_URL:
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {
-            "hosts": [REDIS_URL]
-        },
+        "CONFIG": {"hosts": [REDIS_URL]},
     }
 }


### PR DESCRIPTION
## Description
- Added settings required by the issue

## Linked Issue
Closes #38 

## Changes
### Docs
- None

### Code
- modified server/core/settings.py so if debug off settings required by the issue (and manage.py) are set

### Disclaimer
- You can test it by setting debug to false and running:
`manage.py check --deploy`

all the warnings (except the secret key length warning if it is not modified in your .env) should disappear