### PR TITLE
auth chat consumers in ws connections

### DIFF
--- a/docs/WEBSOCKET_EVENTS.md
+++ b/docs/WEBSOCKET_EVENTS.md
@@ -8,12 +8,17 @@ This document describes the WebSocket endpoints and events available in the appl
 
 This endpoint allows clients to connect to a specific chat room to send and receive real-time messages.
 
+### Authentication
+
+This endpoint uses Django's standard **session-cookie authentication** — the same mechanism as every other API in the project. The browser must have a valid `sessionid` cookie (obtained by logging in via the REST API) before opening the WebSocket connection. `AuthMiddlewareStack` in `core/asgi.py` reads that cookie and populates `scope["user"]` automatically.
+
+Unauthenticated WebSocket connections are briefly accepted so the server can send a clear application-specific close code. The connection is then immediately closed with code `4001`, which this project defines as `AUTHENTICATION_FAILED`.
+
 ### Connection
-To connect to a chat room, establish a WebSocket connection to the endpoint with the desired `room_name`.
+To connect to a chat room, establish a WebSocket connection to the endpoint with the desired `room_name`. A valid session cookie must be present in the request.
 ```
 ws://127.0.0.1:8000/ws/chat/<room_name>/
 ```
-*Note: Authentication via JWT token is planned for the future.*
 
 ### Sending Messages (Client to Server)
 
@@ -39,7 +44,7 @@ When a valid message is sent to the chat room, the server broadcasts it to all c
   "timestamp": "2026-04-07T12:34:56.789Z"
 }
 ```
-*Note: Current `sender_username` is a placeholder ("Mr. Player") and will be dynamically assigned from the authenticated user's JWT token in the future.*
+`sender_username` is the `username` of the authenticated user who sent the message, read directly from `scope["user"]`.
 
 #### 2. Invalid Message Error
 If the client sends a payload that does not match the expected schema or exceeds the maximum length, the server responds with an error message to the sender.

--- a/server/social/consumers.py
+++ b/server/social/consumers.py
@@ -6,8 +6,13 @@ from .services import create_chat_message
 
 
 class ChatConsumer(AsyncJsonWebsocketConsumer):
-    # TODO: add authentication (JWT token) and get the username from the token
     async def connect(self):
+        user = self.scope["user"]
+        if not user.is_authenticated:
+            await self.accept()
+            await self.close(code=4001)
+            return
+
         self.room_name = self.scope["url_route"]["kwargs"]["room_name"]
         self.room_group_name = f"chat_{self.room_name}"
 
@@ -16,7 +21,9 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
 
     # Remember to manually close possible future processes
     async def disconnect(self, close_code):
-        await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+        # room_group_name is only set when an authenticated connection succeeded.
+        if hasattr(self, "room_group_name"):
+            await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
 
     async def receive_json(self, content, **kwargs):
         input_serializer = ChatMessageSerializer(data=content)
@@ -28,7 +35,7 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
             return
 
         message = input_serializer.validated_data["message"]
-        sender = "Mr. Player"  # TODO: get sender's username from the scope (JWT token)
+        sender = self.scope["user"].username
 
         await self.channel_layer.group_send(
             self.room_group_name,

--- a/server/social/tests/test_chat_ws.py
+++ b/server/social/tests/test_chat_ws.py
@@ -1,114 +1,220 @@
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
+from django.contrib.auth import get_user_model, SESSION_KEY, BACKEND_SESSION_KEY, HASH_SESSION_KEY
+from django.contrib.sessions.backends.db import SessionStore
 from channels.testing import WebsocketCommunicator
-from social.routing import websocket_urlpatterns
 from channels.auth import AuthMiddlewareStack
-from channels.security.websocket import AllowedHostsOriginValidator
 from channels.routing import URLRouter
+from channels.db import database_sync_to_async
+from social.routing import websocket_urlpatterns
 from social.models import ChatMessage
 from rest_framework.test import APIClient
 
+User = get_user_model()
 
-class ChatTests(TestCase):
-	async def test_chat_consumer(self):
-		""""Correct use of the endpoint"""
-		application = AllowedHostsOriginValidator(
-        AuthMiddlewareStack(URLRouter(websocket_urlpatterns)))
-		communicator = WebsocketCommunicator(application, "/ws/chat/test_room/")
+# Reuse a single application instance across all WS tests.
+# AllowedHostsOriginValidator is intentionally omitted here — it checks the
+# Origin header against ALLOWED_HOSTS, which is not configured in the test
+# environment and would reject every connection before auth even runs.
+# The real ASGI stack in asgi.py includes it; that behaviour is covered by
+# integration/staging tests.
+APPLICATION = AuthMiddlewareStack(URLRouter(websocket_urlpatterns))
 
-		connected, subprotocol = await communicator.connect()
-		self.assertTrue(connected)
 
-		await communicator.send_json_to({"message": "Halo halo dupa123!"})
+async def _make_auth_communicator(user, path="/ws/chat/test_room/"):
+    """
+    Build a WebsocketCommunicator that carries a valid Django session cookie
+    for `user`.
 
-		response = await communicator.receive_json_from()
-		self.assertEqual(response["message"], "Halo halo dupa123!")
-		self.assertEqual(response["sender_username"], "Mr. Player")
-		self.assertIn("timestamp", response, "No timestamp!")
-		await communicator.disconnect()
+    AuthMiddlewareStack uses Django's SessionMiddleware under the hood, so
+    creating a real SessionStore entry and passing its key as the `sessionid`
+    cookie is the correct way to authenticate a WebSocket in tests — the same
+    path the browser takes in production.
+    """
+    session = SessionStore()
+    session[SESSION_KEY] = str(user.pk)
+    session[BACKEND_SESSION_KEY] = "django.contrib.auth.backends.ModelBackend"
+    session[HASH_SESSION_KEY] = user.get_session_auth_hash()
+    await database_sync_to_async(session.save)()
+    headers = [(b"cookie", f"sessionid={session.session_key}".encode())]
+    return WebsocketCommunicator(APPLICATION, path, headers=headers)
 
-	async def test_chat_consumer_invalid_input(self):
-		"""Incorrect use of the endpoint - missing 'message' key"""
-		application = AllowedHostsOriginValidator(
-        AuthMiddlewareStack(URLRouter(websocket_urlpatterns)))
-		communicator = WebsocketCommunicator(application, "/ws/chat/test_room/")
-		
-		await communicator.connect()
 
-		await communicator.send_json_to({"bad_key": "Failed"})
+# ---------------------------------------------------------------------------
+# Authentication enforcement
+# ---------------------------------------------------------------------------
 
-		response = await communicator.receive_json_from()
-		
-		self.assertIn("error", response)
-		self.assertEqual(response["error"], "Invalid message format.")
-		self.assertIn("details", response)
-		
-		await communicator.disconnect()
-			
-	async def test_chat_consumer_message_too_long(self):
-		"""Testing limit of 500 characters in message"""
-		application = AllowedHostsOriginValidator(
-        AuthMiddlewareStack(URLRouter(websocket_urlpatterns)))
-		communicator = WebsocketCommunicator(application, "/ws/chat/test_room/")
-		await communicator.connect()
+class ChatAuthTests(TransactionTestCase):
+    """Verify that ChatConsumer enforces authentication at connect time."""
 
-		too_long_message = "A" * 501 
-		await communicator.send_json_to({"message": too_long_message})
+    async def test_anonymous_connection_closed_with_4001(self):
+        """
+        A connection with no session cookie must be accepted at the protocol
+        level (the WS handshake must complete before a close frame can be
+        sent) and then immediately closed with code 4001.
 
-		response = await communicator.receive_json_from()
-		
-		self.assertIn("error", response)
-		self.assertEqual(response["error"], "Invalid message format.")
-		self.assertIn("message", response["details"]) 
-		
-		await communicator.disconnect()
+        Clients should treat 4001 as 'not authenticated' and redirect to login.
+        """
+        communicator = WebsocketCommunicator(APPLICATION, "/ws/chat/test_room/")
 
+        connected, _ = await communicator.connect()
+        # The server calls accept() before close() — so connected is True here.
+        self.assertTrue(connected)
+
+        # The very next message from the server must be a close frame with code 4001.
+        message = await communicator.receive_output()
+        self.assertEqual(message["type"], "websocket.close")
+        self.assertEqual(message["code"], 4001)
+
+        await communicator.disconnect()
+
+    async def test_authenticated_connection_accepted(self):
+        """A user with a valid session should connect without being closed."""
+        user = await database_sync_to_async(User.objects.create_user)(
+            username="alice", password="s3cr3t"
+        )
+        communicator = await _make_auth_communicator(user)
+
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        # No immediate close frame — connection stays open.
+        self.assertTrue(await communicator.receive_nothing())
+
+        await communicator.disconnect()
+
+    async def test_broadcast_carries_real_username(self):
+        """
+        The sender_username field in every broadcast must be the authenticated
+        user's actual username — never a placeholder like 'Mr. Player'.
+        """
+        user = await database_sync_to_async(User.objects.create_user)(
+            username="alice", password="s3cr3t"
+        )
+        communicator = await _make_auth_communicator(user)
+        await communicator.connect()
+
+        await communicator.send_json_to({"message": "hello room"})
+        response = await communicator.receive_json_from()
+
+        self.assertEqual(response["sender_username"], "alice")
+        self.assertEqual(response["message"], "hello room")
+        self.assertIn("timestamp", response)
+
+        await communicator.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Functional / message validation tests (require authenticated user)
+# ---------------------------------------------------------------------------
+
+class ChatConsumerTests(TransactionTestCase):
+    """
+    Tests for ChatConsumer message handling.
+
+    Uses TransactionTestCase (not TestCase) because database_sync_to_async
+    runs DB operations on a worker thread. TestCase wraps each test in a
+    transaction on the main thread's connection; the worker thread can't
+    share it and gets a closed connection. TransactionTestCase commits for
+    real, so worker threads can see the data.
+
+    All connections are authenticated — an unauthenticated communicator would
+    be rejected before any message handling runs.
+    """
+
+    def setUp(self):
+        # Sync setUp is required — Django's test runner calls setUp() without
+        # await even when test methods are async. Since this runs on the main
+        # thread (not a worker), a plain ORM call works fine here.
+        self.user = User.objects.create_user(username="testuser", password="pass")
+
+    async def _communicator(self, path="/ws/chat/test_room/"):
+        return await _make_auth_communicator(self.user, path)
+
+    async def test_valid_message_broadcast(self):
+        """A well-formed message is echoed back with username and timestamp."""
+        communicator = await self._communicator()
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.send_json_to({"message": "Halo halo dupa123!"})
+        response = await communicator.receive_json_from()
+
+        self.assertEqual(response["message"], "Halo halo dupa123!")
+        self.assertEqual(response["sender_username"], "testuser")
+        self.assertIn("timestamp", response)
+
+        await communicator.disconnect()
+
+    async def test_invalid_message_key(self):
+        """Missing 'message' key returns an error payload, connection stays open."""
+        communicator = await self._communicator()
+        await communicator.connect()
+
+        await communicator.send_json_to({"bad_key": "Failed"})
+        response = await communicator.receive_json_from()
+
+        self.assertIn("error", response)
+        self.assertEqual(response["error"], "Invalid message format.")
+        self.assertIn("details", response)
+
+        await communicator.disconnect()
+
+    async def test_message_too_long(self):
+        """Messages exceeding 500 characters return a validation error."""
+        communicator = await self._communicator()
+        await communicator.connect()
+
+        await communicator.send_json_to({"message": "A" * 501})
+        response = await communicator.receive_json_from()
+
+        self.assertIn("error", response)
+        self.assertEqual(response["error"], "Invalid message format.")
+        self.assertIn("message", response["details"])
+
+        await communicator.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Chat history REST API tests (unchanged, kept here for co-location)
+# ---------------------------------------------------------------------------
 
 class ChatHistoryAPITests(TestCase):
-	def setUp(self):
-		from django.contrib.auth import get_user_model
-		User = get_user_model()
-		self.user = User.objects.create_user(username='testuser', password='password')
-		
-		self.client = APIClient()
-		self.client.force_authenticate(user=self.user)
-		self.room_name = "test_lobby"
-		
-		ChatMessage.objects.create(
-			room_name=self.room_name, 
-			sender_username="Alice", 
-			message="Pierwsza wiadomość"
-		)
-		ChatMessage.objects.create(
-			room_name=self.room_name, 
-			sender_username="Bob", 
-			message="Druga wiadomość"
-		)
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.room_name = "test_lobby"
 
-	def test_get_chat_history_returns_200_and_data(self):
-		"""Getting chat history and expecting 200 OK """
-		response = self.client.get(f'/social/chat/{self.room_name}/history/')
-		
-		self.assertEqual(response.status_code, 200)
-		
-		data = response.json()
-		self.assertEqual(len(data), 2)
-		
-		self.assertEqual(data[0]["sender_username"], "Alice")
-		self.assertEqual(data[1]["message"], "Druga wiadomość")
+        ChatMessage.objects.create(
+            room_name=self.room_name,
+            sender_username="Alice",
+            message="Pierwsza wiadomość",
+        )
+        ChatMessage.objects.create(
+            room_name=self.room_name,
+            sender_username="Bob",
+            message="Druga wiadomość",
+        )
 
-	def test_get_chat_history_pagination_limit(self):
-		"""Testing if endpoint correctly caps at 50 messages limit"""
-		for i in range(55):
-			ChatMessage.objects.create(
-				room_name=self.room_name, 
-				sender_username="Spammer", 
-				message=f"Spam message {i}"
-			)
-			
-		response = self.client.get(f'/social/chat/{self.room_name}/history/')
-		self.assertEqual(response.status_code, 200)
-		
-		data = response.json()
-		
-		self.assertEqual(len(data), 50)
-		
+    def test_get_chat_history_returns_200_and_data(self):
+        """Getting chat history returns 200 OK with the stored messages."""
+        response = self.client.get(f"/social/chat/{self.room_name}/history/")
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["sender_username"], "Alice")
+        self.assertEqual(data[1]["message"], "Druga wiadomość")
+
+    def test_get_chat_history_pagination_limit(self):
+        """Endpoint caps at 50 messages regardless of how many exist."""
+        for i in range(55):
+            ChatMessage.objects.create(
+                room_name=self.room_name,
+                sender_username="Spammer",
+                message=f"Spam message {i}",
+            )
+
+        response = self.client.get(f"/social/chat/{self.room_name}/history/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 50)


### PR DESCRIPTION
- connect() now reads scope["user"] and rejects unauthenticated connections with close code 4001 (accept-then-close, as required by the WebSocket protocol — a close frame can only be sent after the handshake completes). 
- sender_username is now read from scope["user"].username instead of the hardcoded "Mr. Player".
- added tests


If you wanna test manually:

anonymous rejection:
```
wscat -c "ws://127.0.0.1:8000/ws/chat/testroom/"
# Disconnected (code: 4001)
```

 authenticated message carries real username:

```
curl -c cookies.txt -X POST http://127.0.0.1:8000/account/users/login/ \
  -H "Content-Type: application/json" \
  -d '{"username": "your_user", "password": "your_password"}'

SESSION=$(grep sessionid cookies.txt | awk '{print $NF}')
wscat -c "ws://127.0.0.1:8000/ws/chat/testroom/" -H "Cookie: sessionid=$SESSION"
# send: {"message": "hello"}
# receive: {"message": "hello", "sender_username": "your_user_username", "timestamp": "..."}
```