### PR TITLE
Vite proxy fix

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
 	server: {
 		proxy: {
       '/api': {
-        target: 'https://localhost:8000',
+        target: 'http://127.0.0.1:8000',
 				secure: false,
 				changeOrigin: true,
 			},


### PR DESCRIPTION
Changed `localhost` to `127.0.0.1`. With localhost it wasn't able to connect with the server when run with `make dev-client`