### PR TITLE
104 rewrite lobbies to have questions upon creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ DJANGO_SUPERUSER_PASSWORD=admin
 ALLOWED_HOSTS=localhost,127.0.0.1,localhost:${HTTPS_EXPOSED_PORT},127.0.0.1:${HTTPS_EXPOSED_PORT}
 CSRF_TRUSTED_ORIGINS=https://localhost:${HTTPS_EXPOSED_PORT},https://127.0.0.1:${HTTPS_EXPOSED_PORT},http://localhost:5173,http://127.0.0.1:5173
 REDIS_HOST=redis
+QUESTIONS_PER_SESSION=10
 
 # --- AI Configuration ---
 LLM_API_KEY=sk-example-llm-api-key

--- a/server/core/settings.py
+++ b/server/core/settings.py
@@ -230,3 +230,6 @@ CHANNEL_LAYERS = {
         "CONFIG": {"hosts": [REDIS_URL]},
     }
 }
+
+QUESTIONS_PER_SESSION = int(os.getenv("QUESTIONS_PER_SESSION", "10"))
+

--- a/server/game/services/game_flow/game_service.py
+++ b/server/game/services/game_flow/game_service.py
@@ -28,8 +28,7 @@ from .lifecycle import (
 	handle_disconnect_in_lobby,
 	handle_disconnect_in_answering,
 	handle_disconnect_in_nomination,
-	handle_evaluate_timeout,
-	assign_random_questions_to_session
+	handle_evaluate_timeout
 )
 
 from .answers import (
@@ -113,7 +112,6 @@ class GameService:
 		require_actor_is_host(self.session, actor, "start the game")
 		require_minimum_players(self.session)
 		
-		assign_random_questions_to_session(self.session, amount=10)
 		require_questions_exist(self.session)
 		
 		starting_player = get_random_alive_player(self.session)

--- a/server/game/services/game_flow/guards.py
+++ b/server/game/services/game_flow/guards.py
@@ -17,12 +17,12 @@ def require_questions_exist(session: GameSession) -> None:
 		raise ValidationError("Cannot start game without questions")
 
 
-def require_enough_questions_in_db(amount: int) -> None:
+def require_enough_questions_in_db(limit: int) -> None:
 	available = Question.objects.count()
 	if available == 0:
 		raise ValidationError("Cannot start game without questions in the database.")
-	if available < amount:
-		raise ValidationError(f"Not enough questions. Required: {amount}, available: {available}.")
+	if available < limit:
+		raise ValidationError(f"Not enough questions. Required: {limit}, available: {available}.")
 
 
 def require_starting_player(player: SessionPlayer | None) -> None:

--- a/server/game/services/game_flow/lifecycle.py
+++ b/server/game/services/game_flow/lifecycle.py
@@ -2,6 +2,7 @@ from game.models import GameSession, AnswerAttempt, SessionPlayer, Question, Ses
 from django.utils import timezone
 from .guards import require_status, require_enough_questions_in_db
 from django.core.exceptions import ValidationError
+from django.conf import settings
 
 
 def set_end_game_stats(session: GameSession) -> None:
@@ -25,13 +26,15 @@ def set_end_game_stats(session: GameSession) -> None:
 	session.current_attempt = None
 	session.save()
 
-def assign_random_questions_to_session(session: GameSession, amount: int = 10) -> None:
+def assign_random_questions_to_session(session: GameSession) -> None:
 	if session.session_questions.exists():
 		return
 
-	require_enough_questions_in_db(amount)
+	limit = getattr(settings, 'QUESTIONS_PER_SESSION', 10)
 
-	questions = list(Question.objects.order_by('?')[:amount])
+	require_enough_questions_in_db(limit)
+
+	questions = list(Question.objects.order_by('?')[:limit])
 
 	session_questions = [
 		SessionQuestion(session=session, question=q, order_index=i)

--- a/server/game/services/game_flow/lifecycle.py
+++ b/server/game/services/game_flow/lifecycle.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 from .guards import require_status, require_enough_questions_in_db
 from django.core.exceptions import ValidationError
 from django.conf import settings
+import random
 
 
 def set_end_game_stats(session: GameSession) -> None:
@@ -34,7 +35,10 @@ def assign_random_questions_to_session(session: GameSession) -> None:
 
 	require_enough_questions_in_db(limit)
 
-	questions = list(Question.objects.order_by('?')[:limit])
+	all_ids = list(Question.objects.values_list('id', flat=True))
+	sampled_ids = random.sample(all_ids, limit)
+	questions = list(Question.objects.filter(id__in=sampled_ids))
+	random.shuffle(questions)
 
 	session_questions = [
 		SessionQuestion(session=session, question=q, order_index=i)

--- a/server/game/services/lobby/lobby_management.py
+++ b/server/game/services/lobby/lobby_management.py
@@ -3,6 +3,7 @@ from django.db.models import Max
 from game.models import GameSession, SessionPlayer
 from game.selectors.lobby_selectors import get_room_by_uuid
 from .guards import check_can_create_room, check_can_join_room, check_can_destroy_room
+from game.services.game_flow.lifecycle import assign_random_questions_to_session
 
 
 def create_room(*, user) -> GameSession:
@@ -23,6 +24,8 @@ def create_room(*, user) -> GameSession:
         
         session.host_player = player
         session.save(update_fields=['host_player'])
+        
+        assign_random_questions_to_session(session)
         
     return session
 

--- a/server/game/tests/test_game_service.py
+++ b/server/game/tests/test_game_service.py
@@ -127,16 +127,7 @@ class GameServiceTests(TestCase):
 
 		with self.assertRaisesMessage(
 			ValidationError,
-			"Cannot start game without questions in the database.",
-		):
-			GameService(self.session).start_game_session(actor=self.p1)
-
-	def test_start_game_fails_if_not_enough_questions(self):
-		self.session.session_questions.all().delete()
-
-		with self.assertRaisesMessage(
-			ValidationError,
-			"Not enough questions. Required: 10, available: 4.",
+			"Cannot start game without questions",
 		):
 			GameService(self.session).start_game_session(actor=self.p1)
 

--- a/server/game/tests/test_lobby_apis.py
+++ b/server/game/tests/test_lobby_apis.py
@@ -4,13 +4,20 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from game.models import GameSession, SessionPlayer
+from game.models import GameSession, SessionPlayer, Question
 
 User = get_user_model()
 
 class TestRoomCreateApi(APITestCase):
 	def setUp(self):
 		self.user = User.objects.create_user(username="testuser", email="test@test.com", password="password")
+		# Seed questions so that room creation succeeds
+		for i in range(10):
+			Question.objects.create(
+				question_text=f"Question {i}?",
+				correct_answer="Yes",
+				category="general"
+			)
 
 	def test_create_room_success(self):
 		url = reverse('room-create')
@@ -20,6 +27,32 @@ class TestRoomCreateApi(APITestCase):
 		self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 		self.assertIn('session_uuid', response.data)
 		self.assertEqual(GameSession.objects.count(), 1)
+
+	def test_create_room_fails_when_no_questions(self):
+		Question.objects.all().delete()
+		url = reverse('room-create')
+		self.client.force_authenticate(user=self.user)
+		response = self.client.post(url)
+
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+		self.assertIn("error", response.data)
+		self.assertEqual(GameSession.objects.count(), 0)
+
+	def test_create_room_fails_when_not_enough_questions(self):
+		Question.objects.all().delete()
+		for i in range(4):
+			Question.objects.create(
+				question_text=f"Question {i}?",
+				correct_answer="Yes",
+				category="general"
+			)
+		url = reverse('room-create')
+		self.client.force_authenticate(user=self.user)
+		response = self.client.post(url)
+
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+		self.assertIn("error", response.data)
+		self.assertEqual(GameSession.objects.count(), 0)
 
 	def test_create_room_unauthenticated(self):
 		url = reverse('room-create')


### PR DESCRIPTION
## Description
Like we talked I adjusted assigning questions to session to make it work for future AI question generation module.

## Issue
Closes #104 

## Changes
- Moved `assign_random_questions_to_session()` from `start_game_session()` to `create_room()`. Now rooms are created with assigned questions right away.
- Also added new variable in `.env.example` - `QUESTIONS_PER_SESSION` since we are getting rid of settings in the future (#78)