### PR TITLE
138 fix logging bugs

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -57,14 +57,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -102,9 +102,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -187,13 +187,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -204,13 +207,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -221,13 +227,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -238,13 +247,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -255,13 +267,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -272,13 +287,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -289,9 +307,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -306,9 +324,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -325,9 +343,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -342,9 +360,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -631,16 +649,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1252,13 +1270,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -1268,21 +1286,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/scheduler": {
@@ -1308,9 +1326,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1347,17 +1365,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
-      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.2",
-        "tinyglobby": "^0.2.16"
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/server/account/apis.py
+++ b/server/account/apis.py
@@ -58,7 +58,7 @@ class UserListApi(APIView):
     )
     def get(self, request):
         users = user_list()
-        output_serializer = UserOutputSerializer(users, many=True)
+        output_serializer = UserOutputSerializer(users, many=True, context={"request": request})
         return Response(output_serializer.data, status=status.HTTP_200_OK)
 
 
@@ -72,7 +72,7 @@ class UserDetailApi(APIView):
     )
     def get(self, request, user_id: int):
         user = user_get_by_id(user_id=user_id)
-        output_serializer = UserOutputSerializer(user)
+        output_serializer = UserOutputSerializer(user, context={"request": request})
         return Response(output_serializer.data, status=status.HTTP_200_OK)
 
 
@@ -98,7 +98,7 @@ class UserProfileMeApi(APIView):
     @method_decorator(ensure_csrf_cookie)
     def get(self, request):
         profile = profile_get_by_user_id(user_id=request.user.id)
-        output_serializer = UserProfileOutputSerializer(profile)
+        output_serializer = UserProfileOutputSerializer(profile, context={"request": request})
         return Response(output_serializer.data)
 
     @extend_schema(
@@ -120,7 +120,7 @@ class UserProfileMeApi(APIView):
             user=request.user, **input_serializer.validated_data
         )
 
-        output_serializer = UserProfileOutputSerializer(user.profile)
+        output_serializer = UserProfileOutputSerializer(user.profile, context={"request": request})
         return Response(output_serializer.data, status=status.HTTP_200_OK)
 
     @extend_schema(
@@ -167,7 +167,7 @@ class UserProfileListApi(APIView):
     )
     def get(self, request):
         profiles = profile_list()
-        output_serializer = UserProfileOutputSerializer(profiles, many=True)
+        output_serializer = UserProfileOutputSerializer(profiles, many=True, context={"request": request})
         return Response(output_serializer.data, status=status.HTTP_200_OK)
 
 
@@ -179,7 +179,7 @@ class UserProfileDetailApi(APIView):
     )
     def get(self, request, user_id: int):
         profile = profile_get_by_user_id(user_id=user_id)
-        output_serializer = UserProfileOutputSerializer(profile)
+        output_serializer = UserProfileOutputSerializer(profile, context={"request": request})
         return Response(output_serializer.data, status=status.HTTP_200_OK)
 
 
@@ -208,7 +208,7 @@ class UserProfileAvatarApi(APIView):
             profile=profile, **input_serializer.validated_data
         )
 
-        output_serializer = UserProfileOutputSerializer(profile)
+        output_serializer = UserProfileOutputSerializer(profile, context={"request": request})
         return Response(output_serializer.data, status=status.HTTP_200_OK)
 
     @extend_schema(
@@ -244,7 +244,7 @@ class UserRegisterApi(APIView):
 
         user = user_create(**input_serializer.validated_data)
 
-        output_serializer = UserOutputSerializer(user)
+        output_serializer = UserOutputSerializer(user, context={"request": request})
         return Response(output_serializer.data, status=status.HTTP_201_CREATED)
 
 
@@ -277,7 +277,7 @@ class UserLoginApi(APIView):
             )
 
         login(request, user)
-        return Response(UserOutputSerializer(user).data, status=status.HTTP_200_OK)
+        return Response(UserOutputSerializer(user, context={"request": request}).data, status=status.HTTP_200_OK)
 
 class UserLogoutApi(APIView):
     permission_classes = [IsAuthenticated]

--- a/server/account/serializers.py
+++ b/server/account/serializers.py
@@ -108,6 +108,12 @@ class PublicUserSerializer(serializers.ModelSerializer):
 class UserProfileAvatarInputSerializer(serializers.Serializer):
     avatar = serializers.ImageField()
 
+    def validate_avatar(self, value):
+        max_size = 2 * 1024 * 1024 # 2MB
+        if value.size > max_size:
+            raise serializers.ValidationError("Avatar file size must be under 2MB.")
+        return value
+
 
 # ---------------------------------------------------------------------------
 # Login serializer

--- a/server/account/serializers.py
+++ b/server/account/serializers.py
@@ -40,6 +40,13 @@ class UserOutputSerializer(serializers.ModelSerializer):
         model = User
         fields = ["id", "username", "email"]
 
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        request = self.context.get("request")
+        if request and request.user.is_authenticated and request.user != instance:
+            ret.pop("email", None)
+        return ret
+
 
 class UserUpdateInputSerializer(serializers.Serializer):
     username = serializers.CharField(max_length=150, required=False)

--- a/server/account/tests/test_me_endpoints.py
+++ b/server/account/tests/test_me_endpoints.py
@@ -132,3 +132,65 @@ class UserProfileMeTest(APITestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("username", response.data)
+
+    def test_other_users_emails_are_hidden_in_list_and_detail(self):
+        other_user = User.objects.create_user(
+            username="otheruser",
+            password="otherpassword",
+            email="other@example.com",
+        )
+        self.client.login(username="profileuser", password="profilepassword")
+
+        # 1. Test profile list endpoint
+        response = self.client.get(reverse("profile-list"))
+        self.assertEqual(response.status_code, 200)
+        other_profile_data = next(
+            (item for item in response.data if item["user"]["username"] == "otheruser"),
+            None
+        )
+        self.assertIsNotNone(other_profile_data)
+        self.assertNotIn("email", other_profile_data["user"])
+
+        own_profile_data = next(
+            (item for item in response.data if item["user"]["username"] == "profileuser"),
+            None
+        )
+        self.assertIsNotNone(own_profile_data)
+        self.assertEqual(own_profile_data["user"]["email"], "profile@example.com")
+
+        # 2. Test profile detail endpoint (other user)
+        response = self.client.get(reverse("profile-detail", kwargs={"user_id": other_user.id}))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("email", response.data["user"])
+
+        # Test profile detail endpoint (own user)
+        response = self.client.get(reverse("profile-detail", kwargs={"user_id": self.user.id}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["user"]["email"], "profile@example.com")
+
+        # 3. Test user list endpoint
+        response = self.client.get(reverse("user-list"))
+        self.assertEqual(response.status_code, 200)
+        other_user_data = next(
+            (item for item in response.data if item["username"] == "otheruser"),
+            None
+        )
+        self.assertIsNotNone(other_user_data)
+        self.assertNotIn("email", other_user_data)
+
+        own_user_data = next(
+            (item for item in response.data if item["username"] == "profileuser"),
+            None
+        )
+        self.assertIsNotNone(own_user_data)
+        self.assertEqual(own_user_data["email"], "profile@example.com")
+
+        # 4. Test user detail endpoint (other user)
+        response = self.client.get(reverse("user-detail", kwargs={"user_id": other_user.id}))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("email", response.data)
+
+        # Test user detail endpoint (own user)
+        response = self.client.get(reverse("user-detail", kwargs={"user_id": self.user.id}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["email"], "profile@example.com")

--- a/server/account/tests/test_permissions.py
+++ b/server/account/tests/test_permissions.py
@@ -95,3 +95,22 @@ class IsSelfOrReadOnlyTests(APITestCase):
         self.user_b.profile.refresh_from_db()
         self.assertTrue(self.user_b.profile.avatar)
         self.assertEqual(self.user_b.profile.avatar.name, original_avatar_name)
+
+    def test_upload_avatar_exceeding_size_limit_returns_400(self):
+        url = reverse("profile-avatar", kwargs={"user_id": self.user_a.id})
+        large_data = _png_bytes() + (b"0" * (2 * 1024 * 1024 + 1))
+        avatar = SimpleUploadedFile("large.png", large_data, content_type="image/png")
+        response = self.client.post(url, {"avatar": avatar}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("avatar", response.data)
+        self.assertEqual(response.data["avatar"][0], "Avatar file size must be under 2MB.")
+
+    def test_upload_avatar_within_size_limit_succeeds(self):
+        url = reverse("profile-avatar", kwargs={"user_id": self.user_a.id})
+        avatar = SimpleUploadedFile("valid.png", _png_bytes(), content_type="image/png")
+        response = self.client.post(url, {"avatar": avatar}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user_a.profile.refresh_from_db()
+        self.assertTrue(self.user_a.profile.avatar)


### PR DESCRIPTION
# Privacy Leak Fix and Avatar Size Limit Validation

## Overview

Fixed privacy leak of user email addresses in public profiles and user APIs
added a 2MB size limit validation for uploaded avatar images.
ran npm audit fix to resolve vulnerabilities problem

## Linked issues

Closes #138

## Changes

- **Privacy Leak**:

  - Modified `UserOutputSerializer` in `server/account/serializers.py` to dynamically remove the `email` field from the response unless the requesting user is the user being serialized.
  - Updated all views in `server/account/apis.py` to pass the `request` context to `UserOutputSerializer` and `UserProfileOutputSerializer`.
  - Added tests `test_other_users_emails_are_hidden_in_list_and_detail` in `server/account/tests/test_me_endpoints.py` to verify email exposure is restricted on list and detail views.

- **Avatar Size Limit**:
  - Implemented `validate_avatar` in `UserProfileAvatarInputSerializer` inside `server/account/serializers.py` to validate and reject avatar uploads larger than 2MB.
  - Added test cases `test_upload_avatar_exceeding_size_limit_returns_400` and `test_upload_avatar_within_size_limit_succeeds` in `server/account/tests/test_permissions.py` to enforce and verify the 2MB size validation.

## Technical Details

- **Email Privacy check**: Uses `request = self.context.get("request")` to verify `request.user == instance` dynamically in `to_representation`.
- **Avatar Size limit**: Checks `value.size > 2 * 1024 * 1024` on the incoming uploaded image.

## Verification Results

Ran `make dev-test TEST=account`:

- Passed all 38 tests in the `account` Django app successfully.

Ran `make dev-test`:

- Passed all 217 backend tests successfully.

## How to Run

1. Run Django tests locally: `make dev-test`
