### PR TITLE
188 spectator refresh bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,4 @@ playwright-report/
 blob-report/
 playwright/.cache/
 
-subject.pdf
-PR_desc.md
+*.puml

--- a/server/game/selectors/stats_selectors.py
+++ b/server/game/selectors/stats_selectors.py
@@ -8,7 +8,8 @@ from game.models import GameSession, SessionPlayer, AnswerAttempt
 def _query_player_stats(user) -> dict:
     completed_sessions = SessionPlayer.objects.filter(
         user=user,
-        session__current_status=GameSession.Status.GAME_OVER
+        session__current_status=GameSession.Status.GAME_OVER,
+        seat_number__isnull=False
     )
     return completed_sessions.aggregate(
         games_played=Count('id'),

--- a/server/game/services/game_flow/game_service.py
+++ b/server/game/services/game_flow/game_service.py
@@ -196,14 +196,8 @@ class GameService:
 
 	def	disconnect_player(self, actor: SessionPlayer | None) -> None:
 		require_action_actor(actor, "disconnect")
-		
 		if self.session.current_status == GameSession.Status.GAME_OVER:
 			return
-		
-		if actor.seat_number is None:
-			actor.delete()
-			return
-
 		with transaction.atomic():
 			player = SessionPlayer.objects.select_for_update().get(id=actor.id)
 			if player.active_connections > 0:

--- a/server/game/tests/test_game_http.py
+++ b/server/game/tests/test_game_http.py
@@ -652,6 +652,37 @@ class TestUserGameStatsApis(APITestCase):
 		self.assertNotIn('games_hosted', data)
 		self.assertNotIn('top_categories', data)
 
+	def test_spectator_participation_excluded_from_stats(self):
+		session = GameSession.objects.create(
+			current_status=GameSession.Status.GAME_OVER,
+		)
+		host = SessionPlayer.objects.create(
+			session=session,
+			user=self.opponent,
+			display_name="Opponent",
+			seat_number=1,
+			points=20,
+			lives=3
+		)
+		SessionPlayer.objects.create(
+			session=session,
+			user=self.user,
+			display_name="Spectator",
+			seat_number=None,
+			points=0,
+			lives=0
+		)
+		session.host_player = host
+		session.winner = host
+		session.save()
+
+		self.client.force_authenticate(user=self.user)
+		url = reverse('user-game-stats', kwargs={'user_id': self.user.id})
+		response = self.client.get(url)
+
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		self.assertEqual(response.data['games_played'], 0)
+
 	def test_get_other_user_stats(self):
 		self.client.force_authenticate(user=self.opponent)
 		url = reverse('user-game-stats', kwargs={'user_id': self.user.id})

--- a/server/game/tests/test_game_service.py
+++ b/server/game/tests/test_game_service.py
@@ -1210,3 +1210,16 @@ class SpectatorTests(TestCase):
 		self.session.refresh_from_db()
 		self.assertEqual(self.session.current_status, GameSession.Status.ANSWERING)
 
+	def test_spectator_disconnect_preserves_record_for_reconnect(self):
+		self.session.current_status = GameSession.Status.ANSWERING
+		self.session.save()
+		self.spec.active_connections = 1
+		self.spec.save(update_fields=['active_connections'])
+
+		GameService(self.session).disconnect_player(actor=self.spec)
+
+		self.spec.refresh_from_db()
+		self.assertEqual(self.spec.active_connections, 0)
+		self.assertIsNotNone(self.spec.disconnected_at)
+		self.assertTrue(SessionPlayer.objects.filter(id=self.spec.id).exists())
+


### PR DESCRIPTION
## Description
Fixed:
- Spectators are now not deleted from the session upon refresh
- Stats of spectators are not affected by spectated games

## Issues
Closed #188 