### PR TITLE
Increased retries and start_period

### DIFF
--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 30s
     restart: always
 
   redis:


### PR DESCRIPTION
## Descirption
I've noticed that sometimes after running `make fclean` and `make up` there is an error raised of api server being unhealthy, because the check is started before the server is fully built.

## Issues
None

## Changes
- Increased `start_period` to 30s
- Increased number of retries to 10 